### PR TITLE
Remove absolute path assumptions from utils

### DIFF
--- a/cryoCARE.Singularity
+++ b/cryoCARE.Singularity
@@ -33,7 +33,8 @@ From: tensorflow/tensorflow:1.12.0-gpu-py3
         cuda-nvml-dev-9-2=9.2.148-1 \
         cuda-minimal-build-9-2=9.2.148-1 \
         cuda-command-line-tools-9-2=9.2.148-1 \
-        libnccl-dev=2.3.7-1+cuda9.2 && \
+        libnccl-dev=2.3.7-1+cuda9.2 \
+        file && \
     	rm -rf /var/lib/apt/lists/*
     	
     # Install IMOD dependency and wget


### PR DESCRIPTION
Fix #2: Support relative paths in the `reconstruct_tomo` function. Previously, some files were
referenced relative to the start pwd; others were assumed to be relative to the new directory after the chdir call. 

This also includes some minor code cleanup:
- convert `os.system` to `subprocess.run` calls (safer quoting, better
  shell redirection)
- Check for errors running IMOD commands. Raises CalledProcessError.
- Handle working directory changes with a context manager (restores
  old PWD after an exception)
- Include `file` package in the singularity spec to avoid an error when sourcing the IMOD environment.