### PR TITLE
Fix angstrom to nanometer conversion / header output

### DIFF
--- a/example/02_Tomogram_Reconstruction.ipynb
+++ b/example/02_Tomogram_Reconstruction.ipynb
@@ -155,7 +155,7 @@
     "\n",
     "# We convert from angstroms to nanometers, since the\n",
     "# imod-files expect pixel-spacing in nanometers.\n",
-    "pixel_spacing = float(p[1].split()[0])*0.1\n",
+    "pixel_spacing = float(p[0].split()[0])*0.1\n",
     "print('Pixel Spacing in nanometers:', pixel_spacing)"
    ]
   },


### PR DESCRIPTION
The header command needs to be fixed in the tomogram reconstruction notebook as well (unless I'm missing something).